### PR TITLE
Ycom Doku Externe Authentifizierung allgemeine Möglichkeit ergänzt 

### DIFF
--- a/docs/08_extern_auth.md
+++ b/docs/08_extern_auth.md
@@ -77,7 +77,7 @@ $user = rex_ycom_auth::loginWithParams(['login' => $user_id])
 
 Voraussetzung: Der gewünschte YCom-User muss existieren.
 
-Zusätzlich lässt sich bei Bedarf dieser innerhalb des Extension Points `` nutzen, hierzu exemplarisch, bei dem **ohne zusätzlichen Schutz** eine Möglichkeit, die die Nutzung des EP skizziert. Es wird dringend davon abgeraten, diesen Code 1:1 zu implementieren.
+Zusätzlich lässt sich bei Bedarf dieser innerhalb des Extension Points `YCOM_AUTH_USER_CHECK` nutzen, hierzu exemplarisch, bei dem **ohne zusätzlichen Schutz** eine Möglichkeit, die die Nutzung des EP skizziert. Es wird dringend davon abgeraten, diesen Code 1:1 zu implementieren.
 
 ```php
 rex_extension::register('YCOM_AUTH_USER_CHECK', function ($ep) {


### PR DESCRIPTION
Auf Basis von Feedback in Slack mit Dank an @IngoWinter && @skerbis (Im wesentlichen Lösung aus https://github.com/FriendsOfREDAXO/ycom_impersonate/blob/0cdbe6c8c3280bf644f695dfa9e2d0c1874c86ef/boot.php) und zusätzlichen Infos von @rkemmere 