### PR TITLE
YCom Model Classes optional deaktivieren können

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -30,7 +30,9 @@ if (rex::isBackend()) {
 }
 
 rex_ycom::addTable(rex::getTablePrefix() . 'ycom_user');
-rex_yform_manager_dataset::setModelClass(rex::getTablePrefix() . 'ycom_user', rex_ycom_user::class);
+if(rex_config::get('ycom', 'auto_model_class') === true) {
+    rex_yform_manager_dataset::setModelClass(rex::getTablePrefix() . 'ycom_user', rex_ycom_user::class);
+}
 
 if (rex::isBackend() && ('index.php?page=content/edit' == rex_url::currentBackendPage() || 'mediapool' == rex_be_controller::getCurrentPagePart(1))) {
     rex_view::addJsFile($this->getAssetsUrl('ycom_backend.js'));

--- a/package.yml
+++ b/package.yml
@@ -28,4 +28,4 @@ system_plugins:
     - group
 
 default_config:
-    auto_model_class: "true"
+    auto_model_class: true

--- a/package.yml
+++ b/package.yml
@@ -26,3 +26,6 @@ requires:
 system_plugins:
     - auth
     - group
+
+default_config:
+    auto_model_class: "true"

--- a/plugins/auth/pages/settings.php
+++ b/plugins/auth/pages/settings.php
@@ -31,6 +31,7 @@ if ('update' == rex_request('func', 'string')) {
     $this->setConfig('login_field', stripslashes(str_replace('"', '', rex_request('login_field', 'string'))));
     $this->setConfig('session_max_overall_duration', rex_request('session_max_overall_duration', 'int'));
     $this->setConfig('session_duration', rex_request('session_duration', 'int'));
+	$this->setConfig('auto_model_class', rex_request('session_duration', 'bool'));
 
     echo rex_view::success($this->i18n('ycom_auth_settings_updated'));
 }
@@ -70,6 +71,14 @@ $sel_authcookiettl->addOption($this->i18n('ycom_days', 7), '7');
 $sel_authcookiettl->addOption($this->i18n('ycom_days', 14), '14');
 $sel_authcookiettl->addOption($this->i18n('ycom_days', 30), '30');
 $sel_authcookiettl->addOption($this->i18n('ycom_days', 90), '90');
+
+$sel_auto_model_class = new rex_select();
+$sel_auto_model_class->setId('auto_model_class');
+$sel_auto_model_class->setName('auto_model_class');
+$sel_auto_model_class->setSize(1);
+$sel_auto_model_class->addOption('Ja', '1');
+$sel_auto_model_class->addOption('Nein', '0');
+$sel_auto_model_class->setSelected($this->getConfig('auto_model_class'));
 
 $content .= '
 <form action="index.php" method="post" id="ycom_auth_settings">
@@ -200,6 +209,7 @@ $content .= '
 		</div>
 	</fieldset>
 
+
     <fieldset>
             <legend>' . $this->i18n('ycom_auth_config_security') . '</legend>
 
@@ -258,6 +268,20 @@ $content .= '
 
     </fieldset>
 
+	
+	<fieldset>
+		<legend>' . $this->i18n('ycom_auto_model_class') . '</legend>
+		<div class="row">
+			<div class="col-xs-12 col-sm-6">
+				' . $this->i18n('ycom_auto_model_class') . '
+			</div>
+			<div class="col-xs-12 col-sm-6">
+			 	<div class="select-style">
+	              	' . $sel_auto_model_class->get() . '
+			  	</div>
+			</div>
+		</div>
+	</fieldset>
 
 	<div class="row">
 		<div class="col-xs-12 col-sm-6 col-sm-push-6">

--- a/plugins/group/boot.php
+++ b/plugins/group/boot.php
@@ -5,7 +5,9 @@
  * @psalm-scope-this rex_addon
  */
 
-rex_yform_manager_dataset::setModelClass(rex::getTablePrefix() . 'ycom_group', rex_ycom_group::class);
+ if(rex_config::get('ycom', 'auto_model_class') === true) {
+    rex_yform_manager_dataset::setModelClass(rex::getTablePrefix() . 'ycom_group', rex_ycom_group::class);
+}
 rex_ycom::addTable(rex::getTablePrefix() . 'ycom_group');
 
 if (rex::isBackend()) {


### PR DESCRIPTION
![image](https://github.com/yakamara/ycom/assets/3855487/9cab2976-a06e-489e-b5b6-7bd8a6aa2206)

Ich wünsche mir eine Einstellung, in der ich vorgeben kann, welche Model Class verwendet werden soll. 

In einem Projekt möchte ich eigene Verwenden können wie in einem Projekt, in dem ich Profile und Gruppen umfangreich ändere / um eigene Felder ergänze und dafür auch eigene Methoden bereitstellen will, die dann als Model Class eingesetzt sind.

Allerdings kann ich nicht ganz abschätzen, ob es mit einer einfachen Einstellung und der Möglichkeit, eine andere Klasse zu verwenden, hier getan ist.

Betrifft das Anliegen hier: https://github.com/yakamara/yform/issues/1251