### PR TITLE
Getter/Setter für `ycom_user` und `ycom_group` ergänzt

### DIFF
--- a/lib/ycom_user.php
+++ b/lib/ycom_user.php
@@ -96,4 +96,156 @@ class rex_ycom_user extends rex_yform_manager_dataset
         $this->setValue('login_tries', $this->getValue('login_tries') + 1);
         return $this;
     }
+
+    
+    /* Login */
+    /** @api */
+    public function getLogin() : mixed {
+        return $this->getValue("login");
+    }
+    /** @api */
+    public function setLogin(mixed $value) : self {
+        $this->setValue("login", $value);
+        return $this;
+    }
+
+    /* E-Mail */
+    /** @api */
+    public function getEmail() : mixed {
+        return $this->getValue("email");
+    }
+    /** @api */
+    public function setEmail(mixed $value) : self {
+        $this->setValue("email", $value);
+        return $this;
+    }
+
+    /* Passwort */
+    /** @api */
+    public function setPassword(mixed $value) : self {
+        $this->setValue("password", $value);
+        return $this;
+    }
+
+    /* Vorname */
+    /** @api */
+    public function getFirstname() : mixed {
+        return $this->getValue("firstname");
+    }
+    /** @api */
+    public function setFirstname(mixed $value) : self {
+        $this->setValue("firstname", $value);
+        return $this;
+    }
+
+    /* Name */
+    /** @api */
+    public function getName() : mixed {
+        return $this->getValue("name");
+    }
+    /** @api */
+    public function setName(mixed $value) : self {
+        $this->setValue("name", $value);
+        return $this;
+    }
+
+    /* Status */
+    /** @api */
+    public function getStatus() : mixed {
+        return $this->getValue("status");
+    }
+    /** @api */
+    public function setStatus(mixed $value) : self {
+        $this->setValue("status", $value);
+        return $this;
+    }
+
+    /* Aktivierungsschlüssel */
+    /** @api */
+    public function getActivationKey() : mixed {
+        return $this->getValue("activation_key");
+    }
+    /** @api */
+    public function setActivationKey(mixed $value) : self {
+        $this->setValue("activation_key", $value);
+        return $this;
+    }
+
+    /* Nutzungsbedingungen bestätigt */
+    /** @api */
+    public function getTermsofuseAccepted(bool $asBool = false) : mixed {
+        if($asBool) {
+            return (bool) $this->getValue("termsofuse_accepted");
+        }
+        return $this->getValue("termsofuse_accepted");
+    }
+    /** @api */
+    public function setTermsofuseAccepted(int $value = 1) : self {
+        $this->setValue("termsofuse_accepted", $value);
+        return $this;
+    }
+            
+    /* Neues Passwort muss gesetzt werden */
+    /** @api */
+    public function getNewPasswordRequired(bool $asBool = false) : mixed {
+        if($asBool) {
+            return (bool) $this->getValue("new_password_required");
+        }
+        return $this->getValue("new_password_required");
+    }
+    /** @api */
+    public function setNewPasswordRequired(int $value = 1) : self {
+        $this->setValue("new_password_required", $value);
+        return $this;
+    }
+            
+    /* Letzte Aktion */
+    /** @api */
+    public function getLastActionTime() : ?string {
+        return $this->getValue("last_action_time");
+    }
+    /** @api */
+    public function setLastActionTime(string $value) : self {
+        $this->setValue("last_action_time", $value);
+        return $this;
+    }
+
+    /* Letzter erfolgreicher Login */
+    /** @api */
+    public function getLastLoginTime() : ?string {
+        return $this->getValue("last_login_time");
+    }
+    /** @api */
+    public function setLastLoginTime(string $value) : self {
+        $this->setValue("last_login_time", $value);
+        return $this;
+    }
+
+    /* Kündigungszeitpunkt */
+    /** @api */
+    public function getTerminationTime() : ?string {
+        return $this->getValue("termination_time");
+    }
+    /** @api */
+    public function setTerminationTime(string $value) : self {
+        $this->setValue("termination_time", $value);
+        return $this;
+    }
+
+    /* Login Fehlversuche */
+    /** @api */
+    public function getLoginTries() : ?int {
+        return $this->getValue("login_tries");
+    }
+    /** @api */
+    public function setLoginTries(int $value) : self {
+        $this->setValue("login_tries", $value);
+        return $this;
+    }
+
+    /* Gruppen */
+    /** @api */
+    public function getYcomGroups() : ?rex_yform_manager_dataset {
+        return $this->getRelatedDataset("ycom_groups");
+    }
 }

--- a/lib/ycom_user.php
+++ b/lib/ycom_user.php
@@ -173,14 +173,11 @@ class rex_ycom_user extends rex_yform_manager_dataset
 
     /* Nutzungsbedingungen bestätigt */
     /** @api */
-    public function getTermsofuseAccepted(bool $asBool = false) : mixed {
-        if($asBool) {
-            return (bool) $this->getValue("termsofuse_accepted");
-        }
-        return $this->getValue("termsofuse_accepted");
+    public function getTermsofuseAccepted() : bool {
+        return (bool) $this->getValue("termsofuse_accepted");
     }
     /** @api */
-    public function setTermsofuseAccepted(int $value = 1) : self {
+    public function setTermsofuseAccepted(bool $value = true) : self {
         $this->setValue("termsofuse_accepted", $value);
         return $this;
     }

--- a/lib/ycom_user.php
+++ b/lib/ycom_user.php
@@ -184,14 +184,11 @@ class rex_ycom_user extends rex_yform_manager_dataset
             
     /* Neues Passwort muss gesetzt werden */
     /** @api */
-    public function getNewPasswordRequired(bool $asBool = false) : mixed {
-        if($asBool) {
-            return (bool) $this->getValue("new_password_required");
-        }
-        return $this->getValue("new_password_required");
+    public function getNewPasswordRequired() : bool {
+        return (bool) $this->getValue("new_password_required");
     }
     /** @api */
-    public function setNewPasswordRequired(int $value = 1) : self {
+    public function setNewPasswordRequired(bool $value = true) : self {
         $this->setValue("new_password_required", $value);
         return $this;
     }

--- a/plugins/group/lib/ycom_group.php
+++ b/plugins/group/lib/ycom_group.php
@@ -74,4 +74,13 @@ class rex_ycom_group extends rex_yform_manager_dataset
     {
         return $this->getValue('name');
     }
+
+    /** @api */
+    public function setName(mixed $value) : self
+    {
+        $this->setValue("name", $value);
+        return $this;
+    }
+
+
 }


### PR DESCRIPTION
Alle Felder, die auch bei Installation installiert / sichergestellt werden, erhalten korrespondierende Methoden.