### PR TITLE
OTP-Einstellungen in Plugin-Config & Integration von YCOM_CONFIG Endp…

### DIFF
--- a/docs/02_settings.md
+++ b/docs/02_settings.md
@@ -6,26 +6,35 @@ Die Einstellungsseite befindet sich im REDAXO-Backend unter `YCom` > `Einstellun
 
 > Hinweis: Will man die Einstellungen individuell überschreiben, z.B. über eine settings-Datei, dann kann man den ExtensionPoint `YCOM_CONFIG` dazu nutzen
 
-Weiterleitungen          | Erläuterung
------------------------ | ------------
-article_id_jump_ok      | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Login erfolgreich war.
-article_id_jump_not_ok  | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Login fehlgeschlagen ist. Dies kann auch der Login-Artikel sein. (nur für SAML-Authentifizierung)
-article_id_jump_logout  | Ziel-Artikel, zu dem weitergeleitet wird, nachdem Logout erfolgt ist. Dies kann auch der Login-Artikel sein.
-article_id_jump_denied  | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Besucher nicht die passende Gruppen-Berechtigung hat. Z.B., wenn der Benutzer nicht eingeloggt ist oder keine passende Gruppenberechtigung hat. Dies kann auch der Login-Artikel sein.
-article_id_jump_password| (optional) Artikel, in dem das Passwort geändert wird.
-article_id_jump_termsofuse| (optional) Artikel, zu dem der Nutzer weitergeleitet wird, wenn der Besucher die Nutzungsbedingungen akzeptiert hat.
+| Weiterleitungen            | Erläuterung                                                                                                                                                                                                                               |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| article_id_jump_ok         | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Login erfolgreich war.                                                                                                                                                                 |
+| article_id_jump_not_ok     | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Login fehlgeschlagen ist. Dies kann auch der Login-Artikel sein. (nur für SAML-Authentifizierung)                                                                                      |
+| article_id_jump_logout     | Ziel-Artikel, zu dem weitergeleitet wird, nachdem Logout erfolgt ist. Dies kann auch der Login-Artikel sein.                                                                                                                              |
+| article_id_jump_denied     | Ziel-Artikel, zu dem weitergeleitet wird, wenn der Besucher nicht die passende Gruppen-Berechtigung hat. Z.B., wenn der Benutzer nicht eingeloggt ist oder keine passende Gruppenberechtigung hat. Dies kann auch der Login-Artikel sein. |
+| article_id_jump_password   | (optional) Artikel, in dem das Passwort geändert wird.                                                                                                                                                                                    |
+| article_id_jump_termsofuse | (optional) Artikel, zu dem der Nutzer weitergeleitet wird, wenn der Besucher die Nutzungsbedingungen akzeptiert hat.                                                                                                                      |
+| otp_article_id             | (optional) Ziel-Artikel, zu dem weitergeleitet wird, wenn der Nutzer nach dem Login noch ein OTP eingeben muss oder der Benutzer seine OTP-Einstellungen ändert.                                                                          |
 
-Allgemeine Seiten       | Erläuterung
------------------------ | ------------
-Login-Seite             | Kategorie / Artikel, der das Login-Formular enthält.
-Register-Seite          | (optional) Kategorie / Artikel, der das Registrier-Formular enthält.
-Passwort zurücksetzen   | (optional) Kategorie / Artikel, der das Passwort-ändern-Formular enthält.
 
-Login                   | Erläuterung
------------------------ | ------------
-Login-Feld              | Feld, das für den Login berücksichtigt werden soll, z.B. `email` (E-Mail-Adresse des Nutzers) oder `login` (Pseudonym des Nutzers).
+| Allgemeine Seiten     | Erläuterung                                                               |
+|-----------------------|---------------------------------------------------------------------------|
+| Login-Seite           | Kategorie / Artikel, der das Login-Formular enthält.                      |
+| Register-Seite        | (optional) Kategorie / Artikel, der das Registrier-Formular enthält.      |
+| Passwort zurücksetzen | (optional) Kategorie / Artikel, der das Passwort-ändern-Formular enthält. |
 
-Sicherheit              | Erläuterung
------------------------ | ------------
-Authentifizierungsregel | Regel, mit der Bruteforce-Attacken unterbunden werden, z.B. um nach 5 fehlgeschlagenen Logins den entsprechenden Nutzer für 15 Minuten zu sperren.
+| Login      | Erläuterung                                                                                                                         |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| Login-Feld | Feld, das für den Login berücksichtigt werden soll, z.B. `email` (E-Mail-Adresse des Nutzers) oder `login` (Pseudonym des Nutzers). |
 
+| Sicherheit              | Erläuterung                                                                                                                                        |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Authentifizierungsregel | Regel, mit der Bruteforce-Attacken unterbunden werden, z.B. um nach 5 fehlgeschlagenen Logins den entsprechenden Nutzer für 15 Minuten zu sperren. |
+
+| OTP-Einstellungen            | Erläuterung                                                            |
+|------------------------------|------------------------------------------------------------------------|
+| Einschränkungen              | Regel, ob OTP 2FA optional oder verpflichtend sein soll.               |
+| Optionen                     | Regel, ob nur TOTPs, OTPs über E-Mail oder beides erlaubt sein sollen. |
+| Zeitintervall E-Mail         | Nach wie vielen Minuten ein neuer E-Mail-Code generiert werden soll.   |
+| Zeitintervall Authenticators | Nach wie vielen Minuten ein neuer TOTP-Code generiert werden soll.     |
+| Fehlversuche                 | Anzahl der erlaubten Fehlversuche.                                     |

--- a/plugins/auth/lib/injections/otp.php
+++ b/plugins/auth/lib/injections/otp.php
@@ -10,7 +10,7 @@ class rex_ycom_injection_otp extends rex_ycom_injection_abtract
             return false;
         }
 
-        $otp_article_id = (int) rex_addon::get('ycom')->getConfig('otp_article_id');
+        $otp_article_id = (int) rex_ycom_config::get('otp_article_id', 0);
 
         // 1. User ist eingeloggt
         // 2. OTP Article vorhanden => OTP aktiviert ?
@@ -29,7 +29,7 @@ class rex_ycom_injection_otp extends rex_ycom_injection_abtract
         // - user hat überprüfung und keine OTP Session -> zwingend auf otp-article
         // - OTP ist erzwungen.
         $config = rex_ycom_otp_password_config::forCurrentUser();
-        $otp_auth_enforce = rex_addon::get('ycom')->getConfig('otp_auth_enforce');
+        $otp_auth_enforce = rex_ycom_config::get('otp_auth_enforce');
         $enforcedAll = rex_ycom_otp_password::ENFORCED_ALL == $otp_auth_enforce ? true : false;
         if (!($enforcedAll || $config->enabled)) {
             return false;
@@ -44,7 +44,7 @@ class rex_ycom_injection_otp extends rex_ycom_injection_abtract
 
     public function getSettingsContent(): string
     {
-        $addon = rex_addon::get('ycom');
+        $addon = rex_plugin::get('ycom', 'auth');
 
         $selectEnforce = new rex_select();
         $selectEnforce->setId('otp_auth_enforce');
@@ -155,7 +155,7 @@ class rex_ycom_injection_otp extends rex_ycom_injection_abtract
 
     public function triggerSaveSettings(): void
     {
-        $addon = rex_addon::get('ycom');
+        $addon = rex_plugin::get('ycom', 'auth');
         $addon->setConfig('otp_article_id', rex_request('otp_article_id', 'int'));
         $addon->setConfig('otp_auth_enforce', rex_request('otp_auth_enforce', 'string'));
         $addon->setConfig('otp_auth_option', rex_request('otp_auth_option', 'string'));

--- a/plugins/auth/lib/yform/value/ycom_auth_otp.php
+++ b/plugins/auth/lib/yform/value/ycom_auth_otp.php
@@ -12,7 +12,7 @@ class rex_yform_value_ycom_auth_otp extends rex_yform_value_abstract
             return;
         }
 
-        $otp_article_id = (int) rex_addon::get('ycom')->getConfig('otp_article_id');
+        $otp_article_id = (int) rex_ycom_config::get('otp_article_id');
         if (0 == $otp_article_id) {
             return;
         }


### PR DESCRIPTION
…oint

- OTP-Einstellungen werden im ycom/auth namespace (Plugin-Config) gespeichert
- statt Config-Values direkt aus der Datenbank zu holen, wird rex_ycom_config::get() verwendet
    - dadurch sind die OTP-Konfigurationen über den Endpoint YCOM_CONFIG überschreibbar
- Anpassung der Dokumentation